### PR TITLE
Bump to support intl tel input 21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@typescript-eslint/parser": "6.10.0",
         "eslint": "^8.53.0",
         "eslint-plugin-rxjs": "^5.0.2",
-        "intl-tel-input": "^19.0.0",
+        "intl-tel-input": "20",
         "jasmine-core": "~5.1.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
@@ -9122,15 +9122,10 @@
       }
     },
     "node_modules/intl-tel-input": {
-      "version": "19.5.7",
-      "resolved": "https://registry.npmjs.org/intl-tel-input/-/intl-tel-input-19.5.7.tgz",
-      "integrity": "sha512-jw8qKesME8//LbsjFV+haoKZzDNKlLxzLDnSl3jJg+KgmiDtGP5VUrCxI2SQip7+ZOJhGfWYKV3kp1ZYmgg9iQ==",
-      "dev": true,
-      "dependencies": {
-        "prop-types": "^15.8.1",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
+      "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/intl-tel-input/-/intl-tel-input-20.0.4.tgz",
+      "integrity": "sha512-zFvLPiUisD5EpDwrtNpfl/a48uP3WsI/9KIYWRRm8WlIOqwXKTCeb9+2kc+GB64dphzaKTSW/8jfVV9ZN/cF6g==",
+      "dev": true
     },
     "node_modules/ip-address": {
       "version": "9.0.5",
@@ -10398,18 +10393,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -12503,23 +12486,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -12718,31 +12684,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
       }
     },
     "node_modules/react-is": {
@@ -13347,15 +13288,6 @@
       "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
       "dev": true,
       "optional": true
-    },
-    "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
     },
     "node_modules/schema-utils": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@typescript-eslint/parser": "6.10.0",
     "eslint": "^8.53.0",
     "eslint-plugin-rxjs": "^5.0.2",
-    "intl-tel-input": "^19.0.0",
+    "intl-tel-input": "^20.0.0",
     "jasmine-core": "~5.1.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/src/lib/components/intl-tel-input.component.spec.ts
+++ b/src/lib/components/intl-tel-input.component.spec.ts
@@ -43,6 +43,7 @@ describe('IntlTelInputComponent', () => {
 
     it('should convert phone number to E164 format', () => {
         component.options = {
+            initialCountry: 'ch',
             preferredCountries: ['ch'],
             onlyCountries: ['ch', 'fr']
         };
@@ -55,6 +56,7 @@ describe('IntlTelInputComponent', () => {
 
     it('should re-set E164 phone number on countryChange', () => {
         component.options = {
+            initialCountry: 'ch',
             preferredCountries: ['ch'],
             onlyCountries: ['ch', 'fr']
         };

--- a/src/lib/components/intl-tel-input.component.ts
+++ b/src/lib/components/intl-tel-input.component.ts
@@ -10,7 +10,7 @@
 import { AfterViewInit, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { ControlContainer, NgForm } from '@angular/forms';
 import intlTelInput from 'intl-tel-input';
-import { CountryData, IntlTelInputOptions } from '../model/intl-tel-input-options';
+import { IntlTelInputOptions } from '../model/intl-tel-input-options';
 
 @Component({
     selector: 'intl-tel-input',


### PR DESCRIPTION
Hi :)

This pr allow us to use intl-tel-input 21 [Changelog 20](https://github.com/jackocnr/intl-tel-input/releases/tag/v20.0.0) [Changelog 21](https://github.com/jackocnr/intl-tel-input/releases/tag/v21.0.0)

I don't think verison 21 is a big problem for your package (maybe i am wrong :D ) 

I needed to update test unit because of this :

Remove defaultToFirstCountry option as that behaviour was https://github.com/jackocnr/intl-tel-input/issues/1525#issuecomment-1957751527 and so is not recommended (you can always use initialCountry to set the initial country if you wish to)

I decide to add initialCountry: "ch" because it solve test but don't know if it's correct or not.

Another thinks that changes is the way validNumber works :

By default, calling isValidNumber will now default to mobile-only mode (it will only return true for valid mobile numbers), which means it will be https://github.com/jackocnr/intl-tel-input/issues/1535 - if you don't want this, you can pass false as an argument e.g. isValidNumber(false)

It can be solved with another options 'isMobileVerification' with default to true(like intl-tel-input)

What is your opinion on this subject ?